### PR TITLE
add junit4 test plugin in pom.xml, and fix error in parent smart-pom.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target
 
 catalina.home_IS_UNDEFINED
 *.war
+
+# Mac:
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 			<properties>
 				<env>dev</env>
 				<log.level>debug</log.level>
-				<log.url>${catalina.home}/logs</log.url>
+				<!--<log.url>${catalina.home}/logs</log.url>-->
 			</properties>
 			<activation>
 				<activeByDefault>true</activeByDefault>
@@ -33,7 +33,7 @@
 			<properties>
 				<env>pro</env>
 				<log.level>info</log.level>
-				<log.url>${catalina.home}/logs</log.url>
+				<!--<log.url>${catalina.home}/logs</log.url>-->
 			</properties>
 		</profile>
 	</profiles>
@@ -372,10 +372,23 @@
 	
 	<build>
 		<plugins>
+            <!--maven-junit测试插件-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.10</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit4</artifactId>
+                        <version>2.10</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
 			<plugin>
 				<groupId>org.apache.tomcat.maven</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<version>2.7</version>
+                <artifactId>tomcat7-maven-plugin</artifactId>
+                <version>2.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -438,6 +451,16 @@
 				<directory>deploy/${env}</directory>
 			</resource>
 		</resources>
+        <!--配置测试resource路径-->
+		<testResources>
+			<testResource>
+				<directory>src/test/java</directory>
+				<filtering>true</filtering>
+			</testResource>
+			<testResource>
+				<directory>src/test/resources</directory>
+			</testResource>
+		</testResources>
 	</build>
 	
 	<!-- 阿里云镜像 -->

--- a/smart-mvc/pom.xml
+++ b/smart-mvc/pom.xml
@@ -83,6 +83,12 @@
 			<artifactId>druid</artifactId>
 		</dependency>
 
+		<!-- 单元测试 -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+
 		<!-- 日志 -->
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/smart-mvc/src/test/java/com/smart/mvc/util/StringUtilsTest.java
+++ b/smart-mvc/src/test/java/com/smart/mvc/util/StringUtilsTest.java
@@ -1,0 +1,35 @@
+package com.smart.mvc.util;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * 使用Junit 4 进行单元白盒测试 demo
+ *
+ * @author bluetata / Sekito.Lv@gmail.com</br>
+ * @version smart version(1.0)</br>
+ * @date 09/05/18 17:05</br>
+ * @since JDK 1.8</br>
+ */
+public class StringUtilsTest {
+
+    private StringUtils stringUtils;
+    @Before
+    public void init() {
+        stringUtils = new StringUtils();
+    }
+
+    @Test
+    public void isBlank() {
+        assertEquals(true,stringUtils.isBlank(" "));
+    }
+
+    @After
+    public void tearDown() {
+        stringUtils = null;
+    }
+}


### PR DESCRIPTION
* Add ignore policy of Mac PC  in .gitignore file.
* Add `surefire-junit4` plugin to build junit4 test in  **parent smart-pom.xml**.
* Fix pom error in parent smart-pom.xml, those are : 
  * [can't find `${catalina.home}`] ---> comments them on line 25 & 36.
  * Correct wrong configuration `maven-resources-plugin` ,  changed it to `tomcat7-maven-plugin` and set version is *2.2*
* Add test resource component in **parent smart-pom.xml**. It is used to recognize `Maven Test folder`
* Add junit4 reference in **smart-mvc pom.xml**
* Create Junit4 test class `StringUtilsTest.java` and create Junit 4 test case in this class.